### PR TITLE
feat: Add Hex Code Shade Generator tool

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,6 +69,66 @@
       color: #ccc;
       font-size: 14px;
     }
+
+    /* Hex Code Shade Generator Styles */
+    #shades-display {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 15px; /* Spacing between items */
+      justify-content: center; /* Center items if they don't fill the row */
+      margin-top: 20px;
+    }
+
+    /* Styles for items dynamically created by JS for Hex Code Shade Generator.
+       The JS adds classes like 'd-flex', 'align-items-center', etc.
+       These rules aim to style the .shade-item concept.
+       We target the specific structure created by JS.
+    */
+    #shades-display > div.d-flex { /* This is the .shade-item container */
+      background-color: #252525 !important;
+      padding: 10px !important;
+      border: 1px solid #444 !important;
+      border-radius: 6px !important;
+      flex-direction: column !important; /* Stack preview, text, button vertically */
+      align-items: center !important; /* Center items horizontally */
+      width: calc(20% - 15px); /* Aim for 5 items per row, accounting for gap. Adjust as needed. */
+      min-width: 120px; /* Minimum width */
+      box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+      /* gap property on #shades-display handles spacing, mb-2 from JS is okay or can be removed from JS */
+    }
+
+    #shades-display > div.d-flex > div[style*="background-color"] { /* This is the .shade-preview */
+      width: 100% !important; /* Full width of its parent item */
+      height: 60px !important;
+      border-radius: 4px !important;
+      margin-right: 0 !important; /* Override JS inline style */
+      margin-bottom: 8px !important; /* Space below preview */
+       /* background-color is set by JS, border from JS is fine or can be overridden here */
+    }
+
+    #shades-display > div.d-flex > span { /* This is the hex code text */
+      color: #f0f0f0 !important;
+      font-family: monospace !important;
+      font-size: 0.9em !important;
+      margin-bottom: 8px !important;
+      text-align: center !important;
+      word-break: break-all;
+      flex-grow: 0 !important; /* Override JS inline style */
+    }
+
+    #shades-display > div.d-flex > button.btn.btn-sm { /* This is the .copy-shade-btn */
+      background-color: #555 !important;
+      border-color: #666 !important;
+      color: #fff !important;
+      padding: 5px 10px !important;
+      font-size: 0.8em !important;
+      width: 100% !important; /* Make button take full width */
+      margin-left: 0 !important; /* Override JS inline style */
+    }
+    #shades-display > div.d-flex > button.btn.btn-sm:hover {
+      background-color: #666 !important;
+      border-color: #777 !important;
+    }
   </style>
 </head>
 <body>
@@ -169,6 +229,19 @@
             </div>
           </div>
         </div>
+
+<div class="container mt-4">
+  <div class="row">
+    <div class="col-md-6">
+      <div class="panel">
+        <h2>Hex Code Shade Generator</h2>
+        <input type="text" id="hex-color-input" class="form-control mb-3" placeholder="Enter color name or hex code (e.g., Green or #00FF00)">
+        <button id="generate-shades-btn" class="btn btn-primary w-100 mb-3">Generate Shades</button>
+        <div id="shades-display" class="mt-3"></div>
+      </div>
+    </div>
+  </div>
+</div>
 
 <div class="container mt-4">
     <div class="row">
@@ -526,6 +599,144 @@
     copyUuidBtn.addEventListener('click', () => {
       navigator.clipboard.writeText(uuidOutput.value);
       alert('UUID copied to clipboard!');
+    });
+
+    // Hex Code Shade Generator
+    const hexColorInput = document.getElementById('hex-color-input');
+    const generateShadesBtn = document.getElementById('generate-shades-btn');
+    const shadesDisplay = document.getElementById('shades-display');
+
+    function colorNameToHex(colorName) {
+      const lowerColorName = colorName.toLowerCase();
+      const colorMap = {
+        "red": "#FF0000", "green": "#00FF00", "blue": "#0000FF",
+        "white": "#FFFFFF", "black": "#000000", "yellow": "#FFFF00",
+        "cyan": "#00FFFF", "magenta": "#FF00FF", "gray": "#808080",
+        "grey": "#808080", "maroon": "#800000", "olive": "#808000",
+        "lime": "#00FF00", "aqua": "#00FFFF", "teal": "#008080",
+        "navy": "#000080", "purple": "#800080", "silver": "#C0C0C0"
+      };
+      if (colorMap[lowerColorName]) {
+        return colorMap[lowerColorName];
+      }
+      if (isValidHex(colorName)) { // Check if input is already a hex
+        return colorName.startsWith('#') ? colorName : '#' + colorName;
+      }
+      return null;
+    }
+
+    function isValidHex(hex) {
+      if (!hex) return false;
+      const hexPattern = /^#?([0-9A-Fa-f]{6})$/;
+      return hexPattern.test(hex);
+    }
+
+    function generateShades(baseHexColor, count = 10) {
+      if (!isValidHex(baseHexColor)) return [];
+      const hex = baseHexColor.replace('#', '');
+      let r = parseInt(hex.substring(0, 2), 16);
+      let g = parseInt(hex.substring(2, 4), 16);
+      let b = parseInt(hex.substring(4, 6), 16);
+      const shades = [];
+
+      // Generate 'count' shades, including the base color near the middle
+      // The adjustment factors range from -0.8 (darker) to 0.8 (lighter) for 10 shades
+      // For count = 10, step is 1.6 / 9 = ~0.177
+      // We want base color to be one of the shades, so we adjust factors around 0.
+      const step = 1.6 / (count -1);
+      let adjustmentFactor = -0.8;
+
+      for (let i = 0; i < count; i++) {
+        let newR, newG, newB;
+        if (adjustmentFactor < 0) { // Darken
+          newR = Math.round(r * (1 + adjustmentFactor));
+          newG = Math.round(g * (1 + adjustmentFactor));
+          newB = Math.round(b * (1 + adjustmentFactor));
+        } else { // Lighten
+          newR = Math.round(r + (255 - r) * adjustmentFactor);
+          newG = Math.round(g + (255 - g) * adjustmentFactor);
+          newB = Math.round(b + (255 - b) * adjustmentFactor);
+        }
+
+        newR = Math.max(0, Math.min(255, newR));
+        newG = Math.max(0, Math.min(255, newG));
+        newB = Math.max(0, Math.min(255, newB));
+
+        const rHex = newR.toString(16).padStart(2, '0');
+        const gHex = newG.toString(16).padStart(2, '0');
+        const bHex = newB.toString(16).padStart(2, '0');
+        shades.push(`#${rHex}${gHex}${bHex}`);
+
+        adjustmentFactor += step;
+      }
+      // Ensure original color is part of the list if possible (or very close)
+      // A simple way is to replace the middle element or sort by closeness.
+      // For now, the generated shades are progressive.
+      return shades;
+    }
+
+    generateShadesBtn.addEventListener('click', () => {
+      shadesDisplay.innerHTML = ''; // Clear previous results
+      const userInput = hexColorInput.value.trim();
+      if (!userInput) {
+        shadesDisplay.innerHTML = '<p class="error-message">Please enter a color name or hex code.</p>';
+        return;
+      }
+
+      let hexColor = colorNameToHex(userInput);
+
+      if (!hexColor || !isValidHex(hexColor)) {
+        shadesDisplay.innerHTML = `<p class="error-message">Invalid color name or hex code: ${userInput}. Please use format #RRGGBB or a known color name.</p>`;
+        return;
+      }
+
+      // Ensure hexColor has a '#' prefix for consistency
+      if (!hexColor.startsWith('#')) {
+        hexColor = '#' + hexColor;
+      }
+
+      const generatedShades = generateShades(hexColor, 10);
+
+      if (generatedShades.length === 0) {
+        shadesDisplay.innerHTML = '<p class="error-message">Could not generate shades for the provided color.</p>';
+        return;
+      }
+
+      generatedShades.forEach(shade => {
+        const shadeItem = document.createElement('div');
+        shadeItem.className = 'd-flex align-items-center mb-2 p-2 rounded'; // Added padding and rounded corners
+        shadeItem.style.backgroundColor = '#333'; // Darker background for item
+
+        const previewBox = document.createElement('div');
+        previewBox.style.width = '30px';
+        previewBox.style.height = '30px';
+        previewBox.style.backgroundColor = shade;
+        previewBox.style.border = '1px solid #555'; // Border for preview
+        previewBox.style.marginRight = '10px';
+        previewBox.style.borderRadius = '4px'; // Rounded preview
+
+        const shadeText = document.createElement('span');
+        shadeText.textContent = shade;
+        shadeText.style.flexGrow = '1'; // Allow text to take available space
+        shadeText.style.fontFamily = 'monospace';
+
+        const copyBtn = document.createElement('button');
+        copyBtn.textContent = 'Copy';
+        copyBtn.className = 'btn btn-sm btn-secondary ms-2'; // Bootstrap classes for styling
+        copyBtn.style.backgroundColor = '#555'; // Custom button color
+        copyBtn.style.borderColor = '#666';
+
+        copyBtn.addEventListener('click', () => {
+          navigator.clipboard.writeText(shade)
+            .then(() => alert(`Copied ${shade} to clipboard!`))
+            .catch(err => console.error('Failed to copy: ', err));
+        });
+
+        shadeItem.appendChild(previewBox);
+        shadeItem.appendChild(shadeText);
+        shadeItem.appendChild(copyBtn);
+        shadesDisplay.appendChild(shadeItem);
+      });
     });
 
     if ('serviceWorker' in navigator) {


### PR DESCRIPTION
This commit introduces a new tool to the Dev Tools web page: a Hex Code Shade Generator.

Key features:
- You can input a color by its name (e.g., "green", "blue") or as a 6-digit hexadecimal code (e.g., "#FF0000").
- The tool generates 10 shades (lighter and darker variations) of the input color.
- Each shade is displayed with a visual color preview, its hex code, and a "Copy" button to easily copy the hex code to the clipboard.
- Input validation is included to handle incorrect hex formats or unrecognized color names, displaying appropriate error messages.
- The tool is styled to be consistent with the existing dark theme and panel layout of the application.

The implementation includes:
- HTML structure for the input field, generate button, and shades display area.
- JavaScript logic for color name-to-hex conversion, hex validation, shade calculation, dynamic HTML generation for results, and copy-to-clipboard functionality.
- CSS styles for the new elements to ensure a good user experience and visual consistency.